### PR TITLE
Add timeout and BT disconnect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ ARG sbfspot_home=/usr/local/bin/sbfspot.3
 
 ENV SBFSPOT_INTERVAL 600
 
-# install Packages needed for SBFspot usage, tzdata for setting local time, mariadb-common, mariadb-connector-c and ncurses-libs for mysql command, sqlite for sqlite3 command, libcurl for SBFspotUploadDaemon, mosquitto-clients for mosquitto_pub, sed for setConfigValue
-RUN apk --no-cache add boost-date_time bluez-libs libstdc++ sqlite-libs tzdata mariadb-common mariadb-connector-c ncurses-libs sqlite libcurl mosquitto-clients sed
+# install Packages needed for SBFspot usage, tzdata for setting local time, mariadb-common, mariadb-connector-c and ncurses-libs for mysql command, sqlite for sqlite3 command, libcurl for SBFspotUploadDaemon, mosquitto-clients for mosquitto_pub, sed for setConfigValue, coreutils, bluez-deprecated for script
+RUN apk --no-cache add boost-date_time bluez-libs libstdc++ sqlite-libs tzdata mariadb-common mariadb-connector-c ncurses-libs sqlite libcurl mosquitto-clients sed coreutils bluez-deprecated
 
 # copy SBFspot
 COPY --from=builder $sbfspot_home $sbfspot_home

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -72,8 +72,8 @@ ARG sbfspot_home=/usr/local/bin/sbfspot.3
 
 ENV SBFSPOT_INTERVAL 600
 
-# install Packages needed for SBFspot usage, tzdata for setting local time, mariadb-common, mariadb-connector-c and ncurses-libs for mysql command, sqlite for sqlite3 command, libcurl for SBFspotUploadDaemon, mosquitto-clients for mosquitto_pub, sed for setConfigValue
-RUN apk --no-cache add boost-date_time bluez-libs libstdc++ sqlite-libs tzdata mariadb-common mariadb-connector-c ncurses-libs sqlite libcurl mosquitto-clients sed
+# install Packages needed for SBFspot usage, tzdata for setting local time, mariadb-common, mariadb-connector-c and ncurses-libs for mysql command, sqlite for sqlite3 command, libcurl for SBFspotUploadDaemon, mosquitto-clients for mosquitto_pub, sed for setConfigValue, coreutils, bluez-deprecated for script
+RUN apk --no-cache add boost-date_time bluez-libs libstdc++ sqlite-libs tzdata mariadb-common mariadb-connector-c ncurses-libs sqlite libcurl mosquitto-clients sed coreutils bluez-deprecated
 
 # copy SBFspot
 COPY --from=builder $sbfspot_home $sbfspot_home

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -72,8 +72,8 @@ ARG sbfspot_home=/usr/local/bin/sbfspot.3
 
 ENV SBFSPOT_INTERVAL 600
 
-# install Packages needed for SBFspot usage, tzdata for setting local time, mariadb-common, mariadb-connector-c and ncurses-libs for mysql command, sqlite for sqlite3 command, libcurl for SBFspotUploadDaemon, mosquitto-clients for mosquitto_pub, sed for setConfigValue
-RUN apk --no-cache add boost-date_time bluez-libs libstdc++ sqlite-libs tzdata mariadb-common mariadb-connector-c ncurses-libs sqlite libcurl mosquitto-clients sed
+# install Packages needed for SBFspot usage, tzdata for setting local time, mariadb-common, mariadb-connector-c and ncurses-libs for mysql command, sqlite for sqlite3 command, libcurl for SBFspotUploadDaemon, mosquitto-clients for mosquitto_pub, sed for setConfigValue, coreutils, bluez-deprecated for script
+RUN apk --no-cache add boost-date_time bluez-libs libstdc++ sqlite-libs tzdata mariadb-common mariadb-connector-c ncurses-libs sqlite libcurl mosquitto-clients sed coreutils bluez-deprecated
 
 # copy SBFspot
 COPY --from=builder $sbfspot_home $sbfspot_home

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -71,8 +71,8 @@ ARG sbfspot_home=/usr/local/bin/sbfspot.3
 
 ENV SBFSPOT_INTERVAL 600
 
-# install Packages needed for SBFspot usage, tzdata for setting local time, mariadb-common, mariadb-connector-c and ncurses-libs for mysql command, sqlite for sqlite3 command, libcurl for SBFspotUploadDaemon, mosquitto-clients for mosquitto_pub, sed for setConfigValue
-RUN apk --no-cache add boost-date_time bluez-libs libstdc++ sqlite-libs tzdata mariadb-common mariadb-connector-c ncurses-libs sqlite libcurl mosquitto-clients sed
+# install Packages needed for SBFspot usage, tzdata for setting local time, mariadb-common, mariadb-connector-c and ncurses-libs for mysql command, sqlite for sqlite3 command, libcurl for SBFspotUploadDaemon, mosquitto-clients for mosquitto_pub, sed for setConfigValue, coreutils, bluez-deprecated for script
+RUN apk --no-cache add boost-date_time bluez-libs libstdc++ sqlite-libs tzdata mariadb-common mariadb-connector-c ncurses-libs sqlite libcurl mosquitto-clients sed coreutils bluez-deprecated
 
 # copy SBFspot
 COPY --from=builder $sbfspot_home $sbfspot_home

--- a/start.sh
+++ b/start.sh
@@ -17,15 +17,15 @@ getConfigValue() {
 setConfigValue() {
     key=$1
     value=$2
-    temp_value=`getConfigValue $key`
+    temp_value="$(getConfigValue "$key")"
     if [ -n "$temp_value" ]; then   # key found, so update new value
         echo "$sbfspot_cfg_file" | sed "/^$key=.*/c $key=$value" > $confdir/SBFspot.cfg
     else
-        temp_value=`getConfigValue "#$key"`  # search for inactive key
+        temp_value="$(getConfigValue "#$key")"  # search for inactive key
         if [ -n "$temp_value" ]; then  # append key=value after the first match
             echo "$sbfspot_cfg_file" | sed "0,/^#$key/!b;//a$key=$value" > $confdir/SBFspot.cfg
         else
-            temp_value=`getConfigValue "# $key"`   # no inactive key found, test again with space after hashtag
+            temp_value="$(getConfigValue "# $key")"   # no inactive key found, test again with space after hashtag
             if [ -n "$temp_value" ]; then  # append key=value after the first match
                 echo "$sbfspot_cfg_file" | sed "0,/^# $key/!b;//a$key=$value" > $confdir/SBFspot.cfg
             else
@@ -49,15 +49,15 @@ getUploadConfigValue() {
 setUploadConfigValue() {
     key=$1
     value=$2
-    temp_value=`getUploadConfigValue $key`
+    temp_value="$(getUploadConfigValue "$key")"
     if [ -n "$temp_value" ]; then   # key found, so update new value
         echo "$sbfspot_upload_cfg_file" | sed "/^$key=.*/c $key=$value" > $confdir/SBFspotUpload.cfg
     else
-        temp_value=`getUploadConfigValue "#$key"`  # search for inactive key
+        temp_value="$(getUploadConfigValue "#$key")"  # search for inactive key
         if [ -n "$temp_value" ]; then  # append key=value after the first match
             echo "$sbfspot_upload_cfg_file" | sed "0,/^#$key/!b;//a$key=$value" > $confdir/SBFspotUpload.cfg
         else
-            temp_value=`getUploadConfigValue "# $key"`   # no inactive key found, test again with space after hashtag
+            temp_value="$(getUploadConfigValue "# $key")"   # no inactive key found, test again with space after hashtag
             if [ -n "$temp_value" ]; then  # append key=value after the first match
                 echo "$sbfspot_upload_cfg_file" | sed "0,/^# $key/!b;//a$key=$value" > $confdir/SBFspotUpload.cfg
             else
@@ -270,11 +270,11 @@ initDatabase() {
         fi
         exit 0
     elif [ "$DB_STORAGE" = "mysql" ] || [ "$DB_STORAGE" = "mariadb" ]; then
-        HOST=`getConfigValue SQL_Hostname`
-        DB=`getConfigValue SQL_Database`
-        USER=`getConfigValue SQL_Username`
-        PW=`getConfigValue SQL_Password`
-        LOCAL_IP=`ip ro show | grep 'docker0\|eth0' | awk '{print $(NF)}'`
+        HOST=$(getConfigValue SQL_Hostname)
+        DB=$(getConfigValue SQL_Database)
+        USER=$(getConfigValue SQL_Username)
+        PW=$(getConfigValue SQL_Password)
+        LOCAL_IP=$(ip ro show | grep 'docker0\|eth0' | awk '{print $(NF)}')
         
         ERROR_FLAG=0
         if [ -z "$HOST" ]; then
@@ -446,16 +446,24 @@ if [ $SBFSPOT_INTERVAL -lt 60 ]; then
     echo "SBFSPOT_INTERVAL is very short. It will be set to 60 seconds."
 fi
 
-while [ TRUE ]; do
+bt_address=$(getConfigValue BTAddress)
+
+while true; do
+    if [ -n "${bt_address}" ]; then
+        if hcitool con | grep "${bt_address}" > /dev/null; then
+            echo "Disconnecting ${bt_address}..."
+            hcitool dc "${bt_address}"
+        fi
+    fi
     if [ -n "$sbfspotbinary" ]; then
-        timeout 60 $homedir/$sbfspotbinary $sbfspot_options -cfg$confdir/SBFspot.cfg
+        timeout --foreground 180 $homedir/$sbfspotbinary $sbfspot_options -cfg$confdir/SBFspot.cfg
     fi
 
     # if QUIET SBFspot Option is set, produce less output
     if echo $sbfspot_options | grep -q "\-q"; then
-        DELTA=`expr 60 - $SBFSPOT_INTERVAL / 60`
-        if [ `date +%H` -eq 23 ] && [ `date +%M` -ge $DELTA ];then   # last entry of a day
-            if [ `date +%u` -eq 7 ];then   # sunday
+        DELTA=$((60 - SBFSPOT_INTERVAL / 60))
+        if [ $(date +%H) -eq 23 ] && [ $(date +%M) -ge $DELTA ];then   # last entry of a day
+            if [ $(date +%u) -eq 7 ];then   # sunday
 		echo -n "week "
                 date +%W\ %Y
             else                           # all other days

--- a/start.sh
+++ b/start.sh
@@ -448,7 +448,7 @@ fi
 
 while [ TRUE ]; do
     if [ -n "$sbfspotbinary" ]; then
-	$homedir/$sbfspotbinary $sbfspot_options -cfg$confdir/SBFspot.cfg
+        timeout 60 $homedir/$sbfspotbinary $sbfspot_options -cfg$confdir/SBFspot.cfg
     fi
 
     # if QUIET SBFspot Option is set, produce less output


### PR DESCRIPTION
Because sbfspot may sometimes hang and in that case just straight not work anymore until the container is restarted, I added a timeout. And because that might kill sbfspot before it disconnects again, I also added a small section to check if it's still connected and if so, it just instructs hcitool to disconnect the device.

Fixes #13 